### PR TITLE
Use soft links for evilginx certs

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -135,8 +135,8 @@ function setup_evilginx2 () {
     mkdir -p "${evilginx_dir}/crt/${root_domain}"
     for i in evilginx2/phishlets/*.yaml; do
         phishlet=$(echo "${i}" | awk -F "/" '{print $3}' | sed 's/.yaml//g')
-        cp ${certs_path}fullchain.pem "${evilginx_dir}/crt/${root_domain}/${phishlet}.crt"
-        cp ${certs_path}privkey.pem "${evilginx_dir}/crt/${root_domain}/${phishlet}.key"
+        ln -s ${certs_path}fullchain.pem "${evilginx_dir}/crt/${root_domain}/${phishlet}.crt"
+        ln -s ${certs_path}privkey.pem "${evilginx_dir}/crt/${root_domain}/${phishlet}.key"
     done
     # Prepare DNS for evilginx2
     evilginx2_cstring=""


### PR DESCRIPTION
First of all, thanks for your work this project is awesome 😄 

# Description

After checking the setup script a bit I saw that the certificates used by evilginx are being copied instead of just using soft links. I believe that the use of links could ease a lot the process of updating certs when necessary by just running the letsencrypt command again.