### PR TITLE
Adding X-Forwarded-For Address To Gophish Data

### DIFF
--- a/evilginx2/core/http_proxy.go
+++ b/evilginx2/core/http_proxy.go
@@ -179,14 +179,14 @@ func NewHttpProxy(hostname string, port int, cfg *Config, crt_db *CertDb, db *da
             //log.Debug("Rid regex", ridr.FindString(req_url))
             if len(rid_match) != 0 && len(opened_match) == 0 {
                 rid = strings.Split(rid_match, "=")[1]
-                browser = map[string]string{"address": req.RemoteAddr, "user-agent": req.UserAgent()}
+                browser = map[string]string{"address": req.RemoteAddr, "orig-address": req.Header.Get("X-Forwarded-For"), "user-agent": req.UserAgent()}
                 err := database.HandleClickedLink(rid, browser, p.livefeed)
                 if err != nil {
                     log.Error("failed to add clicked link event to database: %s", err)
                 }
             } else if len(rid_match) != 0 && len(opened_match) != 0 {
                 rid = strings.Split(rid_match, "=")[1]
-                browser = map[string]string{"address": req.RemoteAddr, "user-agent": req.UserAgent()}
+                browser = map[string]string{"address": req.RemoteAddr, "orig-address": req.Header.Get("X-Forwarded-For"), "user-agent": req.UserAgent()}
                 err := database.HandleEmailOpened(rid, browser, p.livefeed)
                 if err != nil {
                     log.Error("failed to add email opened event to database: %s", err)


### PR DESCRIPTION
Currently when exporting the Raw Events from Gophish, the RemoteAddr from the http.request is inserted into the browser data in Gophish when a request is logged.  However, since this is being proxied from the local Apache2 server that is part of Evilgophish, it will only show a 127.0.0.1 IP address in that address field.  Added an additional field of orig-address which grabs data from the X-Forwarded-For header provided by Apache2.

Currently, this data would have to be correlated from the Apache logs with the Gophish data.

Such data currently looks like the following (This is retrieved in Gophish from a camapign under Export CSV -> Raw Events):
`{"payload":{"sessionid":["baj8p975a4"]},"browser":{"address":"127.0.0.1:48916","user-agent":"Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/103.0.5060.134 Safari/537.36"}}`

But with the change it looks like this.  (Original IP redacted):
`{"payload":{"sessionid":["baj8p975a4"]},"browser":{"address":"127.0.0.1:44528","orig-address":"REDACTED","user-agent":"Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/103.0.5060.134 Safari/537.36"}}`





















































