### PR TITLE
Add default logging path

### DIFF
--- a/conf/config.json.template
+++ b/conf/config.json.template
@@ -17,7 +17,7 @@
     "migrations_prefix": "db/db_",
     "contact_address": "",
     "logging": {
-        "filename": "",
+        "filename": "/var/log/gophish/gophish.log",
         "level": ""
     }
 }


### PR DESCRIPTION
In order to obtain the password on the first start of Gophish a logging filename should be configured which can be used to retrieve the password