### PR TITLE
Fix broken rid

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,9 +85,9 @@ Usage:
  - subdomains                      - a space separated list of evilginx3 subdomains, can be one if only one
  - root domain bool                - true or false to proxy root domain to evilginx3
  - feed bool                       - true or false if you plan to use the live feed
- - rid replacement                 - replace the gophish default "rid" in phishing URLs with this value
+ - rid replacement                 - replace the gophish default "rid" in phishing URLs with this value. Consider not using rid or user_id
 Example:
-  ./setup.sh example.com "accounts myaccount" false true user_id
+  ./setup.sh example.com "accounts myaccount" false true custom_user_id
 ```
 
 ## Cloudflare Turnstile Setup
@@ -124,9 +124,9 @@ In case you ran `setup.sh` once and already replaced the default `RId` value thr
 Usage:
 ./replace_rid <previous rid> <new rid>
  - previous rid      - the previous rid value that was replaced
- - new rid           - the new rid value to replace the previous
+ - new rid           - the new rid value to replace the previous. Consider not using rid or user_id
 Example:
-  ./replace_rid.sh user_id client_id
+  ./replace_rid.sh custom_user_id new_custom_user_id
 ```
 
 ## Email Campaign Setup

--- a/replace_rid.sh
+++ b/replace_rid.sh
@@ -16,9 +16,9 @@ if [[ $# -ne 2 ]]; then
     print_error "Usage:"
     print_error "./replace_rid <previous rid> <new rid>"
     print_error " - previous rid      - the previous rid value that was replaced"
-    print_error " - new rid           - the new rid value to replace the previous"
+    print_error " - new rid           - the new rid value to replace the previous. Consider not using rid or user_id"
     print_error "Example:"
-    print_error "   ./replace_rid.sh user_id client_id"
+    print_error "   ./replace_rid.sh custom_user_id new_custom_user_id"
 
     exit 2
 fi

--- a/setup.sh
+++ b/setup.sh
@@ -34,9 +34,9 @@ if [[ $# -ne 5 ]]; then
     print_error " - subdomains                      - a space separated list of subdomains to proxy to evilginx3, can be one if only one"
     print_error " - root domain bool                - true or false to proxy root domain to evilginx3"
     print_error " - feed bool                       - true or false if you plan to use the live feed"
-    print_error " - rid replacement                 - replace the gophish default \"rid\" in phishing URLs with this value"
+    print_error " - rid replacement                 - replace the gophish default \"rid\" in phishing URLs with this value. Consider not using rid or user_id"
     print_error "Example:"
-    print_error '  ./setup.sh example.com "accounts myaccount" false true user_id'
+    print_error '  ./setup.sh example.com "accounts myaccount" false true custom_user_id'
 
     exit 2
 fi
@@ -98,6 +98,7 @@ function setup_gophish () {
     fi
     # Replace rid with user input
     find . -type f -exec sed -i "s|client_id|${rid_replacement}|g" {} \;
+    sed -i "s|\"rid\"|\"${rid_replacement}\"|g" evilginx3/core/http_proxy.go
     cd gophish || exit 1
     go build
     cd ..


### PR DESCRIPTION
Current setup is broken. The victim's click gets recorded in gophish only if the user id `rid` parameter is chosen. This PR fixes this issue.

Also in the examples, there is `user_id` which is [heavily used](https://github.com/search?q=repo%3Afin3ss3g0d%2Fevilgophish%20user_id&type=code) in the code. A simple[ find / replace](https://github.com/fin3ss3g0d/evilgophish/blob/main/replace_rid.sh#L39) of that string will break the setup. It's better to suggest a very `custom_user_id` so it's unique enough to survive a find / replace of `replace_rid.sh` in the entire source code.